### PR TITLE
SQL Injection: Attacker-controlled Data Used in SQL Query via `r` in `sqli1Handler`

### DIFF
--- a/util/cookie.go
+++ b/util/cookie.go
@@ -39,8 +39,26 @@ func SetCookie(w http.ResponseWriter, name, value string) {
 }
 
 func GetCookie(r *http.Request, name string) string {
-	cookie, _ := r.Cookie(name)
-	return cookie.Value
+// GetSanitizedUID gets the cookie value and validates it's a valid integer
+func GetSanitizedUID(r *http.Request) (string, error) {
+    cookie, err := r.Cookie("Uid")
+    if err != nil {
+        return "", err
+    }
+    
+    // Validate that uid is a number
+    uid, err := strconv.Atoi(cookie.Value)
+    if err != nil {
+        return "", errors.New("invalid user ID format")
+    }
+    
+    return strconv.Itoa(uid), nil
+}
+
+// Original GetCookie function kept for compatibility
+func GetCookie(r *http.Request, name string) string {
+    cookie, _ := r.Cookie(name)
+    return cookie.Value
 }
 
 func DeleteCookie(w http.ResponseWriter, cookies []string) {

--- a/vulnerability/sqli/function.go
+++ b/vulnerability/sqli/function.go
@@ -31,25 +31,34 @@ func NewProfile()*Profile{
 
 func(p *Profile)UnsafeQueryGetData(uid string)error{
 
-	/* this funciton use to get data Profile from database with vulnerable query */
+    /* this function now uses parameterized queries to prevent SQL injection */
 
-	getProfileSql := fmt.Sprintf(`SELECT p.user_id, p.full_name, p.city, p.phone_number 
-								FROM Profile as p,Users as u 
-								where p.user_id = u.id 
-								and u.id=%s`,uid) //here is the vulnerable query
-	rows, err := DB.Query(getProfileSql)
-	if err != nil{
-		return err  //this will return error query to clien hmmmm.
-	}
-	defer rows.Close()
-	//var profile = Profile{}
-	for rows.Next(){
-		err = rows.Scan(&p.Uid,&p.Name,&p.City,&p.PhoneNumber)
-		if err != nil{
-			log.Printf("Row scan error: %s", err.Error())
-			return err
-		}
-	}
+    // Using parameterized query with placeholders instead of string interpolation
+    getProfileSql := `SELECT p.user_id, p.full_name, p.city, p.phone_number 
+                        FROM Profile as p,Users as u 
+                        where p.user_id = u.id 
+                        and u.id=?`
+    
+    // Using parameterized query execution
+    rows, err := DB.Query(getProfileSql, uid)
+    if err != nil{
+        // Log the actual error but return a generic error message
+        log.Printf("Query error: %s", err.Error())
+        return errors.New("database error occurred")
+    }
+    defer rows.Close()
+    
+    //var profile = Profilenull
+    for rows.Next(){
+        err = rows.Scan(&p.Uid, &p.Name, &p.City, &p.PhoneNumber)
+        if err != nil{
+            log.Printf("Row scan error: %s", err.Error())
+            return errors.New("error processing data")
+        }
+    }
+    return nil
+}
+
 	return nil
 }
 

--- a/vulnerability/sqli/sqli.go
+++ b/vulnerability/sqli/sqli.go
@@ -26,41 +26,52 @@ func (SQLI) SetRouter(r *httprouter.Router) {
 }
 
 func sqli1Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	uid := util.GetCookie(r, "Uid") // many developer use this style. set reference key in cookie with no sanitize
+    // Use the sanitized version to get validated uid
+    uid, err := GetSanitizedUID(r)
+    if err != nil {
+        // Handle invalid uid
+        data := map[string]interfacenull{
+            "error": "Invalid user ID",
+            "title": "Sql Injection",
+        }
+        util.SafeRender(w, r, "template.sqli1", data)
+        return
+    }
 
-	/*
-		this prevent idor injection but not lead to sql injection
+    /*
+        this prevent idor injection but not lead to sql injection
 
-		s := session.New()
-		sid := s.GetSession(r, "id")
-		if( sid != uid){
-			uid = sid
-		} */
+        s := session.New()
+        sid := s.GetSession(r, "id")
+        if( sid != uid){
+            uid = sid
+        } */
 
-	p := NewProfile()
+    p := NewProfile()
 
-	data := make(map[string]interface{}) // data to send to client
+    data := make(map[string]interfacenull) // data to send to client
 
-	if !util.CheckLevel(r) { // level == low
-		err := p.UnsafeQueryGetData(uid)
-		if err != nil {
-			data["error"] = err.Error()
-		}
-	} else {
-		err := p.SafeQueryGetData(uid)
-		if err != nil {
-			data["error"] = "No Data Found"
-			log.Printf("prepare error : %s", err.Error())
-		}
-	}
-	data["title"] = "Sql Injection"
-	data["uid"] = strconv.Itoa(p.Uid)
-	data["name"] = p.Name
-	data["city"] = p.City
-	data["number"] = p.PhoneNumber
+    if !util.CheckLevel(r) { // level == low
+        err := p.UnsafeQueryGetData(uid) // Using sanitized uid with parameterized queries
+        if err != nil {
+            data["error"] = err.Error()
+        }
+    } else {
+        err := p.SafeQueryGetData(uid)
+        if err != nil {
+            data["error"] = "No Data Found"
+            log.Printf("prepare error : %s", err.Error())
+        }
+    }
+    data["title"] = "Sql Injection"
+    data["uid"] = strconv.Itoa(p.Uid)
+    data["name"] = p.Name
+    data["city"] = p.City
+    data["number"] = p.PhoneNumber
 
-	util.SafeRender(w, r, "template.sqli1", data)
+    util.SafeRender(w, r, "template.sqli1", data)
 }
+
 
 func sqli2Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	uid := r.FormValue("uid")


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [19](https://app.stg.shiftleft.io/apps/shiftleft-go-demo/vulnerabilities?appId=shiftleft-go-demo&findingId=19&scan=1)






<details open>
  <summary>Fix Notes</summary>
    <br>
    



The SQL injection vulnerability was fixed by implementing three key changes:
1. Added a new `GetSanitizedUID` function that validates the UID cookie value is a valid integer before using it in database queries
2. Replaced string interpolation (`fmt.Sprintf`) with parameterized queries using placeholders (`?`) in the SQL statement
3. Improved error handling to avoid exposing database error details to clients, replacing them with generic error messages while still logging actual errors server-side
4. Modified the handler to use the new sanitized function to get the UID

These changes conform to OWASP guidelines for preventing SQL injection by properly validating user input and using parameterized queries. The code now separates data from code instructions, making it impossible for an attacker to manipulate the SQL query structure through malicious input.

</details>



<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Attacker controlled data is used in a SQL query without undergoing escaping or validation. This indicates a SQL injection vulnerability.

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 9 (critical)
- <b> CWE: </b> CWE-89: SQL Injection

</details>



<details>
  <summary>Attack Payloads</summary>
    <br>
    
```
[
1. 1 OR 1=1 --
2. 1 UNION SELECT table_name,column_name,1,1 FROM information_schema.columns --
3. 1; DROP TABLE Users; --
]
```



</details>



<details>
  <summary>Testcases</summary>
    <br>
    



```go
package sqli_test

import (
	"database/sql"
	"fmt"
	"net/http"
	"net/http/httptest"
	"strings"
	"testing"
	
	"github.com/DATA-DOG/go-sqlmock"
	"github.com/julienschmidt/httprouter"
)

type ProfileTest struct {
	DB *sql.DB
	mock sqlmock.Sqlmock
}

func TestSQLInjectionVulnerabilities(t *testing.T) {
	// Setup test environment
	db, mock, err := sqlmock.New()
	if err != nil {
		t.Fatalf("Failed to create mock database connection: %v", err)
	}
	defer db.Close()
	
	profileTest := &ProfileTest{
		DB: db,
		mock: mock,
	}
	
	// Run the test cases
	t.Run("Test Attack Payload 1: OR Condition", func(t *testing.T) {
		profileTest.TestORConditionInjection(t)
	})
	
	t.Run("Test Attack Payload 2: UNION SELECT", func(t *testing.T) {
		profileTest.TestUnionSelectInjection(t)
	})
	
	t.Run("Test Attack Payload 3: DROP TABLE", func(t *testing.T) {
		profileTest.TestDropTableInjection(t)
	})
}

// TestORConditionInjection tests the '1 OR 1=1 --' attack payload
func (pt *ProfileTest) TestORConditionInjection(t *testing.T) {
	// Malicious payload
	maliciousUID := "1 OR 1=1 --"
	
	// This is what the actual query would become with the injection
	expectedInjectedQuery := `SELECT p.user_id, p.full_name, p.city, p.phone_number 
								FROM Profile as p,Users as u 
								where p.user_id = u.id 
								and u.id=1 OR 1=1 --`
	
	// Setup mock expectations - simulating what would happen with the injection
	pt.mock.ExpectQuery(strings.Replace(regexp.QuoteMeta(expectedInjectedQuery), `--`, ``, -1)).
		WillReturnRows(sqlmock.NewRows([]string{"user_id", "full_name", "city", "phone_number"}).
			AddRow(1, "Alice", "New York", "123-456-7890").
			AddRow(2, "Bob", "Boston", "987-654-3210").
			AddRow(3, "Admin", "Secret Location", "000-000-0000")) // Multiple rows returned due to the OR 1=1 condition
	
	// Create request with malicious cookie
	req := httptest.NewRequest("GET", "/vulnerable-endpoint", nil)
	cookie := &http.Cookie{Name: "Uid", Value: maliciousUID}
	req.AddCookie(cookie)
	
	// Test the vulnerable function
	p := &Profilenull
	err := p.UnsafeQueryGetData(maliciousUID)
	
	if err != nil {
		t.Errorf("Expected successful query execution with injected payload, got error: %v", err)
	}
	
	// Verify all mock expectations were met
	if err := pt.mock.ExpectationsWereMet(); err != nil {
		t.Errorf("Unfulfilled mock expectations: %s", err)
	}
	
	t.Log("Injection successful: OR condition allowed access to all user records")
}

// TestUnionSelectInjection tests the '1 UNION SELECT table_name,column_name,1,1 FROM information_schema.columns --' attack payload
func (pt *ProfileTest) TestUnionSelectInjection(t *testing.T) {
	// Malicious payload
	maliciousUID := "1 UNION SELECT table_name,column_name,1,1 FROM information_schema.columns --"
	
	// This is what the actual query would become with the injection
	expectedInjectedQuery := `SELECT p.user_id, p.full_name, p.city, p.phone_number 
								FROM Profile as p,Users as u 
								where p.user_id = u.id 
								and u.id=1 UNION SELECT table_name,column_name,1,1 FROM information_schema.columns --`
	
	// Setup mock expectations - simulating database schema exposure
	pt.mock.ExpectQuery(strings.Replace(regexp.QuoteMeta(expectedInjectedQuery), `--`, ``, -1)).
		WillReturnRows(sqlmock.NewRows([]string{"user_id", "full_name", "city", "phone_number"}).
			AddRow(1, "Alice", "New York", "123-456-7890").
			AddRow("users", "password", "1", "1").
			AddRow("users", "username", "1", "1").
			AddRow("users", "id", "1", "1").
			AddRow("profile", "user_id", "1", "1"))
	
	// Create request with malicious cookie
	req := httptest.NewRequest("GET", "/vulnerable-endpoint", nil)
	cookie := &http.Cookie{Name: "Uid", Value: maliciousUID}
	req.AddCookie(cookie)
	
	// Test the vulnerable function
	p := &Profilenull
	err := p.UnsafeQueryGetData(maliciousUID)
	
	if err != nil {
		t.Errorf("Expected successful query execution with UNION SELECT payload, got error: %v", err)
	}
	
	// Verify all mock expectations were met
	if err := pt.mock.ExpectationsWereMet(); err != nil {
		t.Errorf("Unfulfilled mock expectations: %s", err)
	}
	
	t.Log("Injection successful: UNION SELECT leaked database schema information")
}

// TestDropTableInjection tests the '1; DROP TABLE Users; --' attack payload
func (pt *ProfileTest) TestDropTableInjection(t *testing.T) {
	// Malicious payload
	maliciousUID := "1; DROP TABLE Users; --"
	
	// This is what the actual query would become with the injection
	expectedSelectQuery := `SELECT p.user_id, p.full_name, p.city, p.phone_number 
								FROM Profile as p,Users as u 
								where p.user_id = u.id 
								and u.id=1`
	
	expectedDropQuery := `DROP TABLE Users`
	
	// Setup mock expectations for both queries
	pt.mock.ExpectQuery(regexp.QuoteMeta(expectedSelectQuery)).
		WillReturnRows(sqlmock.NewRows([]string{"user_id", "full_name", "city", "phone_number"}).
			AddRow(1, "Alice", "New York", "123-456-7890"))
	
	pt.mock.ExpectExec(regexp.QuoteMeta(expectedDropQuery)).
		WillReturnResult(sqlmock.NewResult(0, 0))
	
	// Create request with malicious cookie
	req := httptest.NewRequest("GET", "/vulnerable-endpoint", nil)
	cookie := &http.Cookie{Name: "Uid", Value: maliciousUID}
	req.AddCookie(cookie)
	
	// Test the vulnerable function
	p := &Profilenull
	err := p.UnsafeQueryGetData(maliciousUID)
	
	if err != nil {
		t.Errorf("Expected successful execution with DROP TABLE payload, got error: %v", err)
	}
	
	// Verify all mock expectations were met
	if err := pt.mock.ExpectationsWereMet(); err != nil {
		t.Errorf("Unfulfilled mock expectations: %s", err)
	}
	
	t.Log("Injection successful: Multiple statements executed including table deletion")
}
```



</details>



<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/3/commits/6f608f0a4ded07f0e5bca46b5281f34dd977cc6b"> vulnerability/sqli/sqli.go </a> </b></li>

<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/3/commits/28bd7d029d31a543be8783d07211fa07bb116033"> util/cookie.go </a> </b></li>

<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/3/commits/be3cb40fbd8704111f515b0b43bb1d732ae4737c"> vulnerability/sqli/function.go </a> </b></li>

  </ul>
</details>
