### PR TITLE
Cross-Site Request Forgery: Overly Permissive CORS Policy in `RenderAsJson`

### DIFF
--- a/util/template.go
+++ b/util/template.go
@@ -21,16 +21,42 @@ func SafeRender(w http.ResponseWriter, r *http.Request, name string, data map[st
 	}
 }
 
-func RenderAsJson(w http.ResponseWriter, data ...interface{}) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET")
+func RenderAsJson(w http.ResponseWriter, data ...interfacenull) {
+	// Define allowed origins instead of using wildcard "*"
+	// This should ideally come from configuration
+	allowedOrigins := []string{
+		"https://yourtrustedomain.com", 
+		"https://anothertrustedomain.com",
+	}
+	
+	// Get the origin from the request header
+	origin := w.Header().Get("Origin")
+	
+	// Check if the origin is in our allowed list
+	allowOrigin := ""
+	for _, allowed := range allowedOrigins {
+		if allowed == origin {
+			allowOrigin = origin
+			break
+		}
+	}
+	
+	// Only set CORS headers if origin is allowed
+	if allowOrigin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET")
+	}
+	
 	w.Header().Set("Content-Type", "application/json")
 	b, err := json.Marshal(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Write(b)
+}
+
 	w.Write(b)
 }
 


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [2](http://localhost:9090/apps/forked-shiftleft-go-demo/vulnerabilities?appId=forked-shiftleft-go-demo&findingId=2&scan=1)








<details>
  <summary>Vulnerability Description</summary>
    <br>
    
The Access-Control-Allow-Origin (CORS) header is set to the `"*"` wildcard, allowing

- <b> Severity: </b> moderate
- <b> CVSS Score: </b> 4 (moderate)
- <b> CWE: </b> CWE-942: Cross-Site Request Forgery

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/34/commits/248f1b74080f9662de225574aad88e43b3089b3f"> util/template.go </a> </b></li>

  </ul>
</details>
