### PR TITLE
Template Injection: HTTP Data Used in HTML Template via `r` in `xss2Handler`

### DIFF
--- a/vulnerability/xss/xss.go
+++ b/vulnerability/xss/xss.go
@@ -85,23 +85,47 @@ func xss2Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		log.Println(err.Error())
 	}
 
-	data := make(map[string]interface{})
+	data := make(map[string]interfacenull)
 
-	js := ` <script>
-			var id = %s
-			var name = "%s"
-			var city = "%s"
-			var number = "%s"
-			</script>` // here is the mistake, render value to a javascript that came from client request
+	// Create a struct to hold the data that needs to be passed to JavaScript
+	jsData := struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		City        string `json:"city"`
+		PhoneNumber string `json:"number"`
+	}{
+		ID:          uid,
+		Name:        p.Name,
+		City:        p.City,
+		PhoneNumber: p.PhoneNumber,
+	}
 
-	inlineJS := fmt.Sprintf(js, uid, p.Name, p.City, p.PhoneNumber)
+	// Safely encode the data as JSON
+	jsonData, err := json.Marshal(jsData)
+	if err != nil {
+		log.Println("Error marshaling JSON:", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Create safe JavaScript that uses the JSON data
+	safeJS := fmt.Sprintf(`<script>
+		// Parse the JSON data safely
+		var profileData = JSON.parse('%s');
+		
+		// Access data through the parsed object
+		var id = profileData.id;
+		var name = profileData.name;
+		var city = profileData.city;
+		var number = profileData.number;
+	</script>`, template.JSEscapeString(string(jsonData)))
 
 	data["title"] = "Cross Site Scripting"
-
-	data["inlineJS"] = template.HTML(inlineJS) // this will render the javascript on client browser
+	data["inlineJS"] = template.HTML(safeJS)
 
 	util.SafeRender(w, r, "template.xss2", data)
 }
+
 
 func HTMLEscapeString(text string) string {
 	filter := regexp.MustCompile("<[^>]*>")


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [27](https://app.stg.shiftleft.io/apps/shiftleft-go-demo/vulnerabilities?appId=shiftleft-go-demo&findingId=27&scan=1)








<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Data from a HTTP request or response is used in HTML rendering. This indicates a template injection vulnerability.

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 8 (critical)
- <b> CWE: </b> CWE-79: Template Injection

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/40/commits/f22a026c8cbfff7229b57580bf57d1c60babb92d"> vulnerability/xss/xss.go </a> </b></li>

  </ul>
</details>
