### PR TITLE
Cross-Site Request Forgery: Overly Permissive CORS Policy in `RenderAsJson`

### DIFF
--- a/util/template.go
+++ b/util/template.go
@@ -21,16 +21,35 @@ func SafeRender(w http.ResponseWriter, r *http.Request, name string, data map[st
 	}
 }
 
-func RenderAsJson(w http.ResponseWriter, data ...interface{}) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET")
+func RenderAsJson(w http.ResponseWriter, data ...interfacenull) {
+	// Get the origin from the request header
+	origin := r.Header.Get("Origin")
+	
+	// Check if the origin is in the allowed list
+	// This should be replaced with your actual allowed origins
+	allowedOrigins := map[string]bool{
+		"https://trusted-domain.com": true,
+		"https://another-trusted.org": true,
+	}
+	
+	// Only set CORS headers for trusted origins
+	if origin != "" && allowedOrigins[origin] {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET")
+	}
+	
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	
 	b, err := json.Marshal(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Write(b)
+}
+
 	w.Write(b)
 }
 


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [2](https://app.stg.shiftleft.io/apps/shiftleft-go-demo/vulnerabilities?appId=shiftleft-go-demo&findingId=2&scan=1)








<details>
  <summary>Vulnerability Description</summary>
    <br>
    
The Access-Control-Allow-Origin (CORS) header is set to the `"*"` wildcard, allowing

- <b> Severity: </b> medium
- <b> CVSS Score: </b> 4 (medium)
- <b> CWE: </b> 942
- <b> Category: </b> Cross-Site Request Forgery

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/45/commits/3fe9172095e97f9dc8e4dfc832cca1c893901808"> util/template.go </a> </b></li>

  </ul>
</details>
