### PR TITLE
Template Injection: HTTP Data Used in HTML Template via `r` in `xss1Handler`

### DIFF
--- a/vulnerability/xss/xss.go
+++ b/vulnerability/xss/xss.go
@@ -33,43 +33,50 @@ func (XSS) SetRouter(r *httprouter.Router) {
 }
 
 func xss1Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	/* template.HTML is a vulnerable function */
-
-	data := make(map[string]interface{})
-
+	// Added Content Security Policy header to prevent script execution
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'none'")
+	
+	data := make(map[string]interfacenull)
+	
 	if r.Method == "GET" {
 		term := r.FormValue("term")
-
-		if util.CheckLevel(r) { // level = high
-			term = HTMLEscapeString(term)
+		
+		// Added input validation before processing
+		if len(term) > 100 {
+			http.Error(w, "Input too long", http.StatusBadRequest)
+			return
+		}
+		
+		// Validate input using a strict pattern
+		validInputPattern := regexp.MustCompile(`^[a-zA-Z0-9\s\-_.,]+$`)
+		if term != "" && !validInputPattern.MatchString(term) {
+			http.Error(w, "Invalid input", http.StatusBadRequest)
+			return
 		}
 
 		if term == "sql injection" {
 			term = "sqli"
 		}
 
-		term = removeScriptTag(term)
 		vulnDetails := GetExp(term)
-
-		notFound := fmt.Sprintf("<b><i>%s</i></b> not found", term)
-		value := fmt.Sprintf("%s", term)
-
-		if term == "" {
-			data["term"] = ""
-		} else if vulnDetails == "" {
-			data["value"] = template.HTML(value)
-			data["term"] = template.HTML(notFound) // vulnerable function
-		} else {
-			vuln := fmt.Sprintf("<b>%s</b>", term)
-			data["value"] = template.HTML(value)
-			data["term"] = template.HTML(vuln)
-			data["details"] = vulnDetails
-		}
-
+		
+		// Pass simple data to templates instead of HTML fragments
+		data["term"] = term
+		data["searchPerformed"] = term != ""
+		data["found"] = vulnDetails != ""
+		data["details"] = vulnDetails
 	}
+	
 	data["title"] = "Cross Site Scripting"
-	util.SafeRender(w, r, "template.xss1", data)
+	
+	// Using html/template directly instead of util.SafeRender
+	tmpl := template.Must(template.ParseFiles("templates/xss1.html"))
+	err := tmpl.Execute(w, data)
+	if err != nil {
+		http.Error(w, "Template rendering error", http.StatusInternalServerError)
+	}
 }
+
 
 func xss2Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	uid := r.FormValue("uid")
@@ -102,11 +109,17 @@ func xss2Handler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	util.SafeRender(w, r, "template.xss2", data)
 }
-
-func HTMLEscapeString(text string) string {
-	filter := regexp.MustCompile("<[^>]*>")
+// This function is deprecated and should never be used as it provides a false sense of security
+// It has been kept for backward compatibility but no handler should call it
+func removeScriptTag(text string) string {
+	// This regex approach is fundamentally flawed for XSS prevention
+	// Proper context-aware escaping should be used via html/template
+	// This function is maintained only for API compatibility
+	filter := regexp.MustCompile("<script*>.*</script>")
 	output := filter.ReplaceAllString(text, "")
-	return html.EscapeString(output)
+	return output
+}
+
 }
 
 func removeScriptTag(text string) string {


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [26](https://app.stg.shiftleft.io/apps/shiftleft-go-demo/vulnerabilities?appId=shiftleft-go-demo&findingId=26&scan=1)






<details open>
  <summary>Fix Notes</summary>
    <br>
    



The code has been completely refactored to address XSS vulnerabilities with multiple layers of defense:

1. **Context-Aware Sanitization**: Replaced unsafe `html.EscapeString()` with proper use of Go's `html/template` package which automatically applies context-aware escaping.

2. **Proper Template Usage**: Replaced `util.SafeRender` with direct usage of Go's standard `html/template` package with error handling.

3. **No HTML in Handler**: Eliminated all HTML markup construction from the handler code. The template now receives only plain data and is responsible for the presentation.

4. **Content Security Policy**: Added CSP headers to restrict script execution as an additional defense layer.

5. **Input Validation**: Implemented strict input validation with length checks and pattern matching to reject potentially malicious inputs before processing.

6. **Boolean Flags**: Added boolean flags like `found` and `searchPerformed` to control template rendering logic without passing HTML fragments.

7. **Error Handling**: Added proper error handling for template rendering failures.

This comprehensive approach follows OWASP and NIST recommendations for XSS prevention by implementing multiple layers of defense: input validation, context-aware output encoding, and content security policy restrictions.

</details>



<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Data from a HTTP request or response is used in HTML rendering. This indicates a template injection vulnerability.

- <b> Severity: </b> high
- <b> CVSS Score: </b> 8 (high)
- <b> CWE: </b> 79
- <b> Category: </b> Template Injection

</details>



<details>
  <summary>Attack Payloads</summary>
    <br>
    
[
1. <img src=x onerror=alert(document.domain)>
2. <sCriPt>setTimeout('alert(document.cookie)',0)</script>
3. <iframe srcdoc="<img src=x onerror=alert('XSS')>"></iframe>


</details>



<details>
  <summary>Testcases</summary>
    <br>
    



```go
package xss_test

import (
	"fmt"
	"html"
	"html/template"
	"net/http"
	"net/http/httptest"
	"net/url"
	"strings"
	"testing"

	"github.com/julienschmidt/httprouter"
)

type XSSTest struct {
	handler func(http.ResponseWriter, *http.Request, httprouter.Params)
}

func NewXSSTest() *XSSTest {
	return &XSSTest{
		handler: xss1Handler,
	}
}

func (x *XSSTest) TestXSSWithImgOnerrorPayload(t *testing.T) {
	// Setup
	payload := "<img src=x onerror=alert(document.domain)>"
	req := createRequestWithPayload(payload)
	w := httptest.NewRecorder()
	
	// Execute
	x.handler(w, req, nil)
	
	// Verify
	response := w.Body.String()
	
	// Check if the payload was properly escaped in the response
	if strings.Contains(response, payload) {
		t.Errorf("XSS Vulnerability: Unescaped payload found in the response")
	}
	
	// Check if the payload was properly sanitized (escaped)
	escapedPayload := html.EscapeString(payload)
	if !strings.Contains(response, escapedPayload) && strings.Contains(response, payload) {
		t.Errorf("Expected payload to be escaped as %s", escapedPayload)
	}
	
	// Verify HTTP status
	if w.Code != http.StatusOK {
		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
	}
	
	fmt.Printf("Test completed: Img onerror payload test\n")
}

func (x *XSSTest) TestXSSWithScriptPayload(t *testing.T) {
	// Setup
	payload := "<sCriPt>setTimeout('alert(document.cookie)',0)</script>"
	req := createRequestWithPayload(payload)
	w := httptest.NewRecorder()
	
	// Execute
	x.handler(w, req, nil)
	
	// Verify
	response := w.Body.String()
	
	// Check for direct script injection
	if strings.Contains(response, "<script") || strings.Contains(response, "setTimeout") {
		t.Errorf("XSS Vulnerability: Script payload found in the response")
	}
	
	// Check if removeScriptTag correctly removes script tags
	// Note: The current implementation is flawed and this test may pass even with the vulnerability
	if strings.Contains(response, "setTimeout('alert(document.cookie)',0)") {
		t.Errorf("Script content wasn't properly filtered")
	}
	
	// Verify HTTP status
	if w.Code != http.StatusOK {
		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
	}
	
	fmt.Printf("Test completed: Script payload test\n")
}

func (x *XSSTest) TestXSSWithIframePayload(t *testing.T) {
	// Setup
	payload := "<iframe srcdoc=\"<img src=x onerror=alert('XSS')>\"></iframe>"
	req := createRequestWithPayload(payload)
	w := httptest.NewRecorder()
	
	// Execute
	x.handler(w, req, nil)
	
	// Verify
	response := w.Body.String()
	
	// Check if the payload was directly injected (vulnerable)
	if strings.Contains(response, payload) {
		t.Errorf("XSS Vulnerability: Unescaped iframe payload found in the response")
	}
	
	// Check if iframe tag exists in response (vulnerable)
	if strings.Contains(response, "<iframe") && strings.Contains(response, "srcdoc") {
		t.Errorf("XSS Vulnerability: iframe with srcdoc attribute found in response")
	}
	
	// Check if the payload was properly sanitized (escaped)
	escapedPayload := html.EscapeString(payload)
	if !strings.Contains(response, escapedPayload) && strings.Contains(response, payload) {
		t.Errorf("Expected payload to be escaped as %s", escapedPayload)
	}
	
	// Verify HTTP status
	if w.Code != http.StatusOK {
		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
	}
	
	fmt.Printf("Test completed: Iframe payload test\n")
}

// Helper function to create an HTTP request with the XSS payload
func createRequestWithPayload(payload string) *http.Request {
	params := url.Valuesnull
	params.Add("term", payload)
	
	req := httptest.NewRequest("GET", "/xss?"+params.Encode(), nil)
	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
	
	return req
}
```

</details>



<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/62/commits/0013a5f06f8cc6cc745b14e88dce97dd82fa99e7"> vulnerability/xss/xss.go </a> </b></li>

  </ul>
</details>
