### PR TITLE
Fix: github.com/gen2brain/go-unarr (GHSA-v9j4-cp63-qv62)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ShiftLeftSecurity/shiftleft-go-demo
 go 1.12
 
 require (
-	github.com/gen2brain/go-unarr v0.1.1
+github.com/gen2brain/go-unarr v0.1.5
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION

# Dependency Vulnerability Fix

This PR was created automatically by the Harness SCA AutoFix tool.

## Fix for Finding **[81](http://localhost:9090/apps/sl-go-demo/vulnerabilities?appId=sl-go-demo&findingId=81&scan=2)**








<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Tarslip in go-unarr

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 9 (critical)
- <b> CWE: </b> 
- <b> Category: </b> 

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/147/commits/bfd8fd6a807b58f3c546643827e7cd7c70305a65"> go.mod </a> </b></li>

  </ul>
</details>
