### PR TITLE
fix: upgrade github.com/gen2brain/go-unarr to v0.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ShiftLeftSecurity/shiftleft-go-demo
 go 1.12
 
 require (
-	github.com/gen2brain/go-unarr v0.1.1
+	github.com/gen2brain/go-unarr v0.1.5
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
### 📝 Description
**Upgrade Version:** `v0.1.5`

**Summary:**
This PR upgrades `github.com/gen2brain/go-unarr` from `v0.1.1` to `v0.1.5` to address GHSA-v9j4-cp63-qv62, a critical tarslip vulnerability that could allow attackers to write files outside the intended extraction directory during archive extraction.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a minor version upgrade and is unlikely to introduce breaking changes, but please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9` | `v0.1.5` | [GHSA-v9j4-cp63-qv62](https://www.cve.org/CVERecord?id=GHSA-v9j4-cp63-qv62) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

**Status:** 🎉 **1 vulnerability** has been reduced/resolved.

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square







<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Tarslip in go-unarr

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 9 (critical)
- <b> CWE: </b> 
- <b> Category: </b> 

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/153/commits/32c99329d4dc0b08719dbdb0cd08714d92f51452"> go.mod </a> </b></li>

  </ul>
</details>
