### PR TITLE
fix: upgrade github.com/tidwall/gjson to v1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/tidwall/gjson v1.9.2
+	github.com/tidwall/gjson v1.9.3
 	github.com/tidwall/match v1.1.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )


### PR DESCRIPTION
### 📝 Description
**Upgrade Version:** `v1.9.3`

**Summary:**
CVE-2021-42836 affects github.com/tidwall/gjson v1.9.2, exposing the application to a Regular Expression Denial of Service (ReDoS) attack. Upgrading to v1.9.3 resolves this vulnerability by fixing the regex implementation that could be exploited to cause excessive CPU consumption.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade (v1.9.2 → v1.9.3), so breaking changes are unlikely. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.5` | `v1.9.3` | [CVE-2021-42836](https://www.cve.org/CVERecord?id=CVE-2021-42836) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square







<details>
  <summary>Vulnerability Description</summary>
    <br>
    
GJSON is a Go package that provides a fast and simple way to get values from a json document. GJSON before 1.9.3 allows a ReDoS (regular expression denial of service) attack.

- <b> Severity: </b> high
- <b> CVSS Score: </b> 7.5 (high)
- <b> CWE: </b> 400, 697, 1333
- <b> Category: </b> 

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/173/commits/d0f0defca23f1ead3f859bef8c29da34cf071d1c"> go.mod </a> </b></li>

  </ul>
</details>
