### PR TITLE
fix: upgrade github.com/tidwall/gjson to v1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/tidwall/gjson v1.9.2
+	github.com/tidwall/gjson v1.9.3
 	github.com/tidwall/match v1.1.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )


### PR DESCRIPTION
### 📝 Description
**Upgrade Version:** `v1.9.3`

**Summary:**
This PR upgrades `github.com/tidwall/gjson` from v1.9.2 to v1.9.3 to address GHSA-ppj4-34rq-v8j9, a Regular Expression Denial of Service (REDoS) vulnerability. The upgrade resolves this security issue without introducing breaking changes.

> [!IMPORTANT]
> **Potential Breaking Changes:** Unlikely — this is a patch version upgrade that focuses on security fixes.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7.0` | `v1.9.3` | [GHSA-ppj4-34rq-v8j9](https://github.com/advisories/GHSA-ppj4-34rq-v8j9) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square







<details>
  <summary>Vulnerability Description</summary>
    <br>
    
github.com/tidwall/gjson Vulnerable to REDoS attack

- <b> Severity: </b> high
- <b> CVSS Score: </b> 7 (high)
- <b> CWE: </b> 
- <b> Category: </b> 

</details>







<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-go-demo/pull/188/commits/8f5c2d0aaf47ea01c435c98c6dcaab36633ba997"> go.mod </a> </b></li>

  </ul>
</details>
