### PR TITLE
fix: upgrade github.com/tidwall/gjson to 1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/tidwall/gjson v1.9.2
+	github.com/tidwall/gjson v1.9.3
 	github.com/tidwall/match v1.1.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[95](http://localhost:9090/apps/go-sca-autofix-9/vulnerabilities?appId=go-sca-autofix-9&findingId=95&scan=1)**




### 📝 Description
**Upgrade Version:** `1.9.3`

**Summary:**
This upgrade addresses a Regular Expression Denial of Service (REDoS) vulnerability (GHSA-ppj4-34rq-v8j9) in github.com/tidwall/gjson v1.9.2. The vulnerability could allow an attacker to cause excessive CPU consumption through specially crafted input. Upgrading to v1.9.3 resolves this security issue.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade, so breaking changes are unlikely. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7` | `1.9.3` | [GHSA-ppj4-34rq-v8j9](https://github.com/advisories/GHSA-ppj4-34rq-v8j9) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

