### PR TITLE
fix: upgrade github.com/tidwall/gjson to v1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/tidwall/gjson v1.9.2
+	github.com/tidwall/gjson v1.9.3
 	github.com/tidwall/match v1.1.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[95](http://localhost:9090/apps/go-sca-autofix-12/vulnerabilities?appId=go-sca-autofix-12&findingId=95&scan=1)**




### 📝 Description
**Upgrade Version:** `1.9.3`

**Summary:**
The current version of `github.com/tidwall/gjson` (v1.9.2) is vulnerable to a Regular Expression Denial of Service (REDoS) attack. This upgrade to v1.9.3 resolves the vulnerability by patching the affected regular expression handling.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade (v1.9.2 → v1.9.3), which typically does not introduce breaking changes. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7` | `1.9.3` | [GHSA-ppj4-34rq-v8j9](https://github.com/advisories/GHSA-ppj4-34rq-v8j9) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

