### PR TITLE
fix: upgrade github.com/tidwall/gjson to 1.9.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/tidwall/gjson v1.9.2
+	github.com/tidwall/gjson v1.9.3
 	github.com/tidwall/match v1.1.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[94](http://localhost:9090/apps/go-sca-autofix-12/vulnerabilities?appId=go-sca-autofix-12&findingId=94&scan=1)**




### 📝 Description
**Upgrade Version:** `1.9.3`

**Summary:**
This upgrade addresses GHSA-c9gm-7rfj-8w5h, a Regular Expression Denial of Service (ReDoS) vulnerability in `github.com/tidwall/gjson` v1.9.2. The vulnerability allows attackers to cause service degradation through specially crafted JSON input. Upgrading to v1.9.3 resolves this security issue.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade and is unlikely to introduce breaking changes.
> Please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 0, High: 1, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![high][high-badge] | `7` | `1.9.3` | [GHSA-c9gm-7rfj-8w5h](https://github.com/advisories/GHSA-c9gm-7rfj-8w5h) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

