### PR TITLE
fix: upgrade go-unarr to v0.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ShiftLeftSecurity/shiftleft-go-demo
 go 1.12
 
 require (
-	github.com/gen2brain/go-unarr v0.1.1
+	github.com/gen2brain/go-unarr v0.1.4
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION

# Harness SAST and SCA AutoFix

This PR was created automatically by the Harness SAST and SCA AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding **[93](http://localhost:9090/apps/go-sca-autofix-16/vulnerabilities?appId=go-sca-autofix-16&findingId=93&scan=1)**




### 📝 Description
**Upgrade Version:** `v0.1.4`

**Summary:**
This upgrade resolves GHSA-v9j4-cp63-qv62, a Tarslip vulnerability in go-unarr affecting version v0.1.1. Upgrading to v0.1.4 eliminates this critical security risk.

> [!IMPORTANT]
> **Potential Breaking Changes:** This is a patch version upgrade, so breaking changes are unlikely. However, please review and test thoroughly before merging.

---

### 🛡️ Security Impact

#### Current version vulnerabilities: 1 (Critical: 1, High: 0, Medium: 0, Low: 0)

| Severity | CVSS Score | Upgrade Version | Reference Identifiers |
| :---: | :--- | :--- | :--- |
| ![critical][critical-badge] | `9.0` | `v0.1.4` | [GHSA-v9j4-cp63-qv62](https://github.com/advisories/GHSA-v9j4-cp63-qv62) |

#### Upgrade version vulnerabilities: 0 (Critical: 0, High: 0, Medium: 0, Low: 0)

[critical-badge]: https://img.shields.io/badge/Critical-d73a4a?style=flat-square
[high-badge]: https://img.shields.io/badge/High-e4a228?style=flat-square
[medium-badge]: https://img.shields.io/badge/Medium-f5c518?style=flat-square
[low-badge]: https://img.shields.io/badge/Low-0075ca?style=flat-square

